### PR TITLE
fix(intl): remove extra slash from base-url

### DIFF
--- a/__tests__/utils/modules.spec.js
+++ b/__tests__/utils/modules.spec.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { fromJS } from 'immutable';
+import { getModuleMap } from 'holocron';
+
+import { getModuleBaseUrl } from '../../src/utils/modules';
+
+jest.mock('holocron');
+
+describe('getModuleBaseUrl', () => {
+  function mockGetModuleMapBaseUrl(moduleName, baseUrl) {
+    getModuleMap.mockImplementationOnce(() => fromJS({
+      modules: {
+        [moduleName]: {
+          baseUrl,
+        },
+      },
+    }));
+  }
+
+  test('gets the baseUrl for a module with a trailing slash', () => {
+    const moduleName = 'my-module';
+    const moduleBaseUrl = `https://example.com/modules/${moduleName}/1.0.0/`;
+    mockGetModuleMapBaseUrl(moduleName, moduleBaseUrl);
+
+    expect(getModuleBaseUrl(moduleName)).toEqual(moduleBaseUrl.slice(0, -1));
+  });
+
+  test('gets the baseUrl for a module without a trailing slash', () => {
+    const moduleName = 'my-module';
+    const moduleBaseUrl = `https://example.com/modules/${moduleName}/1.1.1`;
+    mockGetModuleMapBaseUrl(moduleName, moduleBaseUrl);
+
+    expect(getModuleBaseUrl(moduleName)).toEqual(moduleBaseUrl);
+  });
+});

--- a/__tests__/utils/modules.spec.js
+++ b/__tests__/utils/modules.spec.js
@@ -30,7 +30,7 @@ describe('getModuleBaseUrl', () => {
     }));
   }
 
-  test('gets the baseUrl for a module with a trailing slash', () => {
+  it('should get the baseUrl for a module with a trailing slash and normalizes it', () => {
     const moduleName = 'my-module';
     const moduleBaseUrl = `https://example.com/modules/${moduleName}/1.0.0/`;
     mockGetModuleMapBaseUrl(moduleName, moduleBaseUrl);
@@ -38,7 +38,7 @@ describe('getModuleBaseUrl', () => {
     expect(getModuleBaseUrl(moduleName)).toEqual(moduleBaseUrl.slice(0, -1));
   });
 
-  test('gets the baseUrl for a module without a trailing slash', () => {
+  it('should get the baseUrl for a module without a trailing slash', () => {
     const moduleName = 'my-module';
     const moduleBaseUrl = `https://example.com/modules/${moduleName}/1.1.1`;
     mockGetModuleMapBaseUrl(moduleName, moduleBaseUrl);

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -143,7 +143,7 @@ const getUrl = ({ getState, langPackLocale, componentKey }) => {
   const localeFilename = state.getIn(['config', 'localeFilename']);
 
   return `${[
-    moduleBaseUrl,
+    moduleBaseUrl.replace(/\/$/, ''),
     langPackLocale.toLowerCase(),
     localeFilename || componentKey,
   ].join('/')}.json`;

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -13,8 +13,9 @@
  */
 
 import { fromJS, Map as iMap } from 'immutable';
-import { getModuleMap } from 'holocron';
+
 import typeScope from '../utils/typeScope';
+import { getModuleBaseUrl } from '../utils/modules';
 
 export const defaultLocale = 'en-US';
 
@@ -138,12 +139,11 @@ const langPackToIguazu = ({ getState, componentKey }) => {
 
 const getUrl = ({ getState, langPackLocale, componentKey }) => {
   const state = getState();
-  const moduleMap = getModuleMap();
-  const moduleBaseUrl = moduleMap.getIn(['modules', componentKey, 'baseUrl']);
+  const moduleBaseUrl = getModuleBaseUrl(componentKey);
   const localeFilename = state.getIn(['config', 'localeFilename']);
 
   return `${[
-    moduleBaseUrl.replace(/\/$/, ''),
+    moduleBaseUrl,
     langPackLocale.toLowerCase(),
     localeFilename || componentKey,
   ].join('/')}.json`;

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getModuleMap } from 'holocron';
+
+// eslint-disable-next-line import/prefer-default-export
+export function getModuleBaseUrl(componentKey) {
+  const moduleBaseUrl = getModuleMap().getIn(['modules', componentKey, 'baseUrl']);
+  if (moduleBaseUrl.endsWith('/')) return moduleBaseUrl.slice(0, -1);
+  return moduleBaseUrl;
+}


### PR DESCRIPTION
Removing trailing `/` from `baseUrl` when combined with `[baseUrl, locale, filename].join('/')`.

[Examples of `baseUrl`](https://github.com/americanexpress/one-app/search?q=baseUrl&unscoped_q=baseUrl)