### PR TITLE
fix(intl): use browser url for ssr

### DIFF
--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -339,7 +339,7 @@ describe('intl duck', () => {
         holocron.getModuleMap.mockImplementation(() => fromJS({
           modules: {
             'foo-bar': {
-              baseUrl: 'https://example.com/cdn/foo-bar/1.0.0',
+              browser: { url: 'https://example.com/cdn/foo-bar/1.0.0/foo-bar.browser.js' },
             },
           },
         }));
@@ -595,7 +595,7 @@ describe('intl duck', () => {
         holocron.getModuleMap.mockImplementation(() => fromJS({
           modules: {
             'foo-bar': {
-              baseUrl: 'https://example.com/cdn/foo-bar/1.0.0',
+              browser: { url: 'https://example.com/cdn/foo-bar/1.0.0/foo-bar.browser.js' },
             },
           },
         }));
@@ -636,7 +636,7 @@ describe('intl duck', () => {
         holocron.getModuleMap.mockImplementation(() => fromJS({
           modules: {
             'foo-bar': {
-              baseUrl: 'https://example.com/cdn/foo-bar/1.0.0',
+              browser: { url: 'https://example.com/cdn/foo-bar/1.0.0/foo-bar.browser.js' },
             },
           },
         }));
@@ -666,7 +666,7 @@ describe('intl duck', () => {
         holocron.getModuleMap.mockImplementation(() => fromJS({
           modules: {
             'foo-bar': {
-              baseUrl: 'https://example.com/cdn/foo-bar/1.0.0',
+              browser: { url: 'https://example.com/cdn/foo-bar/1.0.0/foo-bar.browser.js' },
             },
           },
         }));
@@ -703,7 +703,7 @@ describe('intl duck', () => {
           holocron.getModuleMap.mockImplementation(() => fromJS({
             modules: {
               'foo-bar': {
-                baseUrl: 'https://example.com/cdn/foo-bar/1.0.0',
+                browser: { url: 'https://example.com/cdn/foo-bar/1.0.0/foo-bar.browser.js' },
               },
             },
           }));
@@ -737,7 +737,7 @@ describe('intl duck', () => {
           holocron.getModuleMap.mockImplementation(() => fromJS({
             modules: {
               'foo-bar': {
-                baseUrl: 'https://example.com/cdn/foo-bar/1.0.0',
+                browser: { url: 'https://example.com/cdn/foo-bar/1.0.0/foo-bar.browser.js' },
               },
             },
           }));
@@ -935,7 +935,7 @@ describe('intl duck', () => {
         holocron.getModuleMap.mockImplementation(() => fromJS({
           modules: {
             frank: {
-              baseUrl: 'https://example.com/cdn/frank/1.0.0',
+              browser: { url: 'https://example.com/cdn/frank/1.0.0/foo-bar.browser.js' },
             },
           },
         }));

--- a/__tests__/utils/modules.spec.js
+++ b/__tests__/utils/modules.spec.js
@@ -24,7 +24,7 @@ describe('getModuleBaseUrl', () => {
     getModuleMap.mockImplementationOnce(() => fromJS({
       modules: {
         [moduleName]: {
-          baseUrl,
+          browser: { url: baseUrl },
         },
       },
     }));
@@ -32,10 +32,10 @@ describe('getModuleBaseUrl', () => {
 
   it('should get the baseUrl for a module with a trailing slash and normalizes it', () => {
     const moduleName = 'my-module';
-    const moduleBaseUrl = `https://example.com/modules/${moduleName}/1.0.0/`;
+    const moduleBaseUrl = `https://example.com/modules/${moduleName}/1.0.0/${moduleName}.browser.js`;
     mockGetModuleMapBaseUrl(moduleName, moduleBaseUrl);
 
-    expect(getModuleBaseUrl(moduleName)).toEqual(moduleBaseUrl.slice(0, -1));
+    expect(getModuleBaseUrl(moduleName)).toEqual(moduleBaseUrl.replace(/[^/]+\.js$/i, '').slice(0, -1));
   });
 
   it('should get the baseUrl for a module without a trailing slash', () => {

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -16,7 +16,7 @@ import { getModuleMap } from 'holocron';
 
 // eslint-disable-next-line import/prefer-default-export
 export function getModuleBaseUrl(componentKey) {
-  const moduleBaseUrl = getModuleMap().getIn(['modules', componentKey, 'baseUrl']);
+  const moduleBaseUrl = getModuleMap().getIn(['modules', componentKey, 'browser', 'url']).replace(/[^/]+\.js$/i, '');
   if (moduleBaseUrl.endsWith('/')) return moduleBaseUrl.slice(0, -1);
   return moduleBaseUrl;
 }


### PR DESCRIPTION
`getModuleUrl` used `baseUrl` to construct the url required to request the language pack. 

However, `baseUrl` is an additional key created for the [clientModuleMapCache](https://github.com/americanexpress/one-app/blob/0c64dcd7b76018868c37101e50ef2228c25a3eec/src/server/utils/clientModuleMapCache.js#L26) that makes the Module Map available to the client by passing it as initial state in [sendHtml](https://github.com/americanexpress/one-app/blob/49a382699a41bbac77c48863d7603b43c23ef387/src/server/middleware/sendHtml.js#L231) to set the moduleMap when [initClient()](https://github.com/americanexpress/one-app/blob/0c64dcd7b76018868c37101e50ef2228c25a3eec/src/client/initClient.jsx#L31) runs.

The reason we are setting the `moduleMapCache` is because the client doesn't have access to the loaded modules on the server, however the server always has the most up to date version of the module map.

This solution uses the `browser` key in the module map which is available on both the `clientModuleMapCache` and the `moduleMap` already available on the server.

Tested this solution with the `queryLanguageDta` and a clean module generated with intl, the language pack now loads on the server on the first render
 ```
Component rerender: 1
LangpackTest.jsx:16 languageData =>  {locale: "en-US", greeting: "Welcome to langpack-test from the United States!"}
LangpackTest.jsx:17 isLoading =>  false
```

Tested with `cultured-frankie` and `loadLanguageData` however, even though the language pack renders on the server on the first render, the `moduleStatus` property only changes from `loading` to `loaded` on the second render, this has been identified as a separate bug and will be addressed separately.