### PR TITLE
fix(errorReporting): use right url from config to send client errors to

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ store.dispatch(clearError());
 
 ### `errorReporting` Duck
 
-The error reporting duck is for sending client side errors to the `errorReportingUrl` configured by
+The error reporting duck is for sending client side errors to the `reportingUrl` configured by
 the  environment variable `ONE_CLIENT_REPORTING_URL`. You can find more documentation on environment
 variables for One App in the [One App documentation](https://github.com/americanexpress/one-app/blob/master/runtime-configuration.md).
 On the server the errors reported are simply logged with the assumption that the underlying

--- a/__tests__/errorReporting.spec.js
+++ b/__tests__/errorReporting.spec.js
@@ -195,7 +195,7 @@ describe('error reporting', () => {
         },
       ];
       const store = mockStore({
-        config: fromJS({ errorReportingUrl: '/home' }),
+        config: fromJS({ reportingUrl: '/home' }),
         errorReporting: fromJS({
           queue,
           pending: [],
@@ -238,7 +238,7 @@ describe('error reporting', () => {
         },
       ];
       const store = mockStore({
-        config: fromJS({ errorReportingUrl: '/home' }),
+        config: fromJS({ reportingUrl: '/home' }),
         errorReporting: fromJS({
           queue,
           pending: [],
@@ -268,7 +268,7 @@ describe('error reporting', () => {
         },
       ];
       const store = mockStore({
-        config: fromJS({ errorReportingUrl: '/home' }),
+        config: fromJS({ reportingUrl: '/home' }),
         errorReporting: fromJS({
           queue,
           pending: [],
@@ -296,7 +296,7 @@ describe('error reporting', () => {
         },
       ];
       const store = mockStore({
-        config: fromJS({ errorReportingUrl: '/home' }),
+        config: fromJS({ reportingUrl: '/home' }),
         errorReporting: fromJS({
           queue,
           pending: [],
@@ -330,7 +330,7 @@ describe('error reporting', () => {
       ];
       const pendingPromise = new Promise((res) => { resolvePendingPromise = res; });
       const store = mockStore({
-        config: fromJS({ errorReportingUrl: '/home' }),
+        config: fromJS({ reportingUrl: '/home' }),
         errorReporting: fromJS({
           queue,
           pending: [],
@@ -363,7 +363,7 @@ describe('error reporting', () => {
 
       const store = createStore(
         combineReducers({
-          config: () => fromJS({ errorReportingUrl: '/home' }),
+          config: () => fromJS({ reportingUrl: '/home' }),
           errorReporting: reducer,
         }),
         applyMiddleware(thunk.withExtraArgument({ fetchClient: fetch }))
@@ -399,7 +399,7 @@ describe('error reporting', () => {
       expect.assertions(1);
       const store = createStore(
         combineReducers({
-          config: () => fromJS({ errorReportingUrl: '/home' }),
+          config: () => fromJS({ reportingUrl: '/home' }),
           errorReporting: reducer,
         }),
         applyMiddleware(thunk.withExtraArgument({ fetchClient: fetch }))
@@ -415,7 +415,7 @@ describe('error reporting', () => {
         });
     });
 
-    it('should use the errorReportingUrl config', () => {
+    it('should use the reportingUrl config', () => {
       expect.assertions(2);
 
       const testError = { message: 'test error' };
@@ -424,7 +424,7 @@ describe('error reporting', () => {
 
       const store = createStore(
         combineReducers({
-          config: () => fromJS({ errorReportingUrl }),
+          config: () => fromJS({ reportingUrl: errorReportingUrl }),
           errorReporting: reducer,
         }),
         applyMiddleware(thunk.withExtraArgument({ fetchClient: fetch }))

--- a/src/errorReporting.js
+++ b/src/errorReporting.js
@@ -106,7 +106,7 @@ function thenSendErrorReport({
   return promise
     .then(() => {
       const state = getState();
-      const reportingUrl = state.getIn(['config', 'errorReportingUrl']);
+      const reportingUrl = state.getIn(['config', 'reportingUrl']);
       const queue = state.getIn(['errorReporting', 'queue']).toJS();
 
       if (queue.length === 0) {


### PR DESCRIPTION
One App's ONE_CLIENT_REPORTING_URL env var is converted to `reportingUrl` in the redux store.

Prior to this fix the error reporting duck was looking for the wrong key name in the redux store and thus no client errors were being sent to the server for log aggregation.