### PR TITLE
fix(errorReporting): truncated server console log

### DIFF
--- a/__tests__/errorReporting.spec.js
+++ b/__tests__/errorReporting.spec.js
@@ -19,6 +19,7 @@ import { combineReducers } from 'redux-immutable';
 import configureStore from 'redux-mock-store';
 
 // Module under test
+import util from 'util';
 import reducer, {
   serverSideError,
   addErrorToReport,
@@ -310,7 +311,7 @@ describe('error reporting', () => {
 
       return store.dispatch(sendErrorReport())
         .then((data) => {
-          expect(consoleErrorSpy).toHaveBeenCalledWith(queue);
+          expect(consoleErrorSpy).toHaveBeenCalledWith(util.inspect(queue, false, null, true));
           expect(store.getActions().length).toBe(2);
           expect(store.getActions()[0].type).toEqual(SEND_ERROR_REPORT_REQUEST);
           expect(store.getActions()[1].type).toEqual(SEND_ERROR_REPORT_SUCCESS);
@@ -378,7 +379,7 @@ describe('error reporting', () => {
           msg: testError.message,
           stack: testError.stack,
           href: 'about:blank',
-          otherData: JSON.stringify({ ...otherData }),
+          otherData,
         },
       ];
 
@@ -449,7 +450,7 @@ describe('error reporting', () => {
       expect.assertions(1);
       const err = new Error('this is a test');
       return serverSideError(err).then(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(err);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(util.inspect(err, false, null, true));
       });
     });
 
@@ -490,7 +491,7 @@ describe('error reporting', () => {
       const otherData = { foo: 'bar' };
       const result = formatErrorReport(testError, otherData);
 
-      expect(result.otherData).toBe(JSON.stringify(otherData));
+      expect(result.otherData).toBe(otherData);
     });
   });
 });

--- a/src/errorReporting.js
+++ b/src/errorReporting.js
@@ -14,6 +14,7 @@
 
 /* eslint no-bitwise: ["error", { "int32Hint": true }] */
 import { fromJS } from 'immutable';
+import util from 'util';
 import typeScope from './utils/typeScope';
 
 // action constants
@@ -41,7 +42,7 @@ export function formatErrorReport(error, otherData) {
     // TODO: use StackTrace to format the stack?
     stack: error && error.stack, // IE >= 10
     href: global.BROWSER ? global.location.href : undefined,
-    otherData: JSON.stringify(otherData),
+    otherData,
   };
 }
 
@@ -96,7 +97,9 @@ function getPendingPromise(state) {
 }
 
 export function serverSideError(error) {
-  console.error(error);
+  // nodejs console truncates output by default
+  // https://nodejs.org/api/util.html#util_util_inspect_object_options
+  console.error(util.inspect(error, false, null, true));
   return Promise.resolve({ thankYou: true });
 }
 


### PR DESCRIPTION
reverts: https://github.com/americanexpress/one-app-ducks/pull/5

fixes: https://github.com/americanexpress/one-app/issues/36#issuecomment-587152336

Description:

1. Trying to spread an object that has already been passed to `JSON.stringify()` (string) will spread each character in the string. https://github.com/americanexpress/one-app/blob/master/src/server/middleware/clientErrorLogger.js#L52

After removing the call to `JSON.stringify()` on the `otherData` object the client side error is now being parsed and sent correctly by One App's `clientErrorLogger`

2. The nodejs console truncates objects by default when they exceed a depth of 3. reported in this issue 
fixes: https://github.com/americanexpress/one-app/issues/36#issuecomment-587152336

This issue was only present when trying to log the error to the console server side.

Implemented https://nodejs.org/api/util.html#util_util_inspect_object_options to expand the objects and even give a nice colour to the console error 😉


