### PR TITLE
fix(error-reporting): custom console object depth

### DIFF
--- a/__tests__/errorReporting.spec.js
+++ b/__tests__/errorReporting.spec.js
@@ -311,7 +311,7 @@ describe('error reporting', () => {
 
       return store.dispatch(sendErrorReport())
         .then((data) => {
-          expect(consoleErrorSpy).toHaveBeenCalledWith(util.inspect(queue, false, null, true));
+          expect(consoleErrorSpy).toHaveBeenCalledWith(util.inspect(queue, false, 10, true));
           expect(store.getActions().length).toBe(2);
           expect(store.getActions()[0].type).toEqual(SEND_ERROR_REPORT_REQUEST);
           expect(store.getActions()[1].type).toEqual(SEND_ERROR_REPORT_SUCCESS);
@@ -450,7 +450,7 @@ describe('error reporting', () => {
       expect.assertions(1);
       const err = new Error('this is a test');
       return serverSideError(err).then(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(util.inspect(err, false, null, true));
+        expect(consoleErrorSpy).toHaveBeenCalledWith(util.inspect(err, false, 10, true));
       });
     });
 

--- a/src/errorReporting.js
+++ b/src/errorReporting.js
@@ -99,7 +99,7 @@ function getPendingPromise(state) {
 export function serverSideError(error) {
   // nodejs console truncates output by default
   // https://nodejs.org/api/util.html#util_util_inspect_object_options
-  console.error(util.inspect(error, false, null, true));
+  console.error(util.inspect(error, false, 10, true));
   return Promise.resolve({ thankYou: true });
 }
 


### PR DESCRIPTION
Setting the depth of the recursive console.log to 10 instead of null (infinite) in case someone passes a huge object to be logged and that causes a maximum call stack exceeded error and kills the server. https://nodejs.org/api/util.html#util_util_inspect_object_options