### PR TITLE
fix(intl): support wildcard for Accept-Language header

### DIFF
--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -111,6 +111,12 @@ describe('intl duck', () => {
       expect(state.get('activeLocale')).toBe('en-US');
     });
 
+    it('should use the default locale when accepts languages is a wildcard', () => {
+      const req = { cookies: {}, acceptsLanguages: () => ['*'] };
+      const state = buildInitialState({ req });
+      expect(state.get('activeLocale')).toBe('en-US');
+    });
+
     it('should use the default locale when navigator.language is undefined', () => {
       const { navigator } = global;
       delete global.navigator;

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -38,7 +38,10 @@ function buildInitialState({ req } = {}) {
     activeLocale = (navigator && navigator.language) || defaultLocale;
   } else {
     const acceptsLanguages = req.acceptsLanguages();
-    activeLocale = (acceptsLanguages && acceptsLanguages[0]) || defaultLocale;
+    activeLocale = acceptsLanguages && acceptsLanguages[0];
+    if (!activeLocale || activeLocale === '*') {
+      activeLocale = defaultLocale;
+    }
   }
 
   return fromJS({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set the `activeLocale` to the default locale when a wildcard is passed for Accept-Language.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the `Accept-Language` header on a request is set to `"*"`, the value of the `activeLocale` in state will also be set to `"*"`, which is not generally going to be a valid locale value by consumers.

For instance, if passed to react-intl, the following error occurs:
```
RangeError: '*' is not a structurally valid language tag
```

Using a wildcard for Accept-Language is not common but it is in the spec: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language

Fixes #30. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Fix was straightforward so primary testing was in unit tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
<!--- Please describe how your changes impacts developers using one-app-ducks. -->
If someone was dependent on the `activeLocale` being set to "*", their code may stop working properly. 