### PR TITLE
fix(intl): rm err errExp upon lang req and success

### DIFF
--- a/__tests__/intl/__snapshots__/index.spec.js.snap
+++ b/__tests__/intl/__snapshots__/index.spec.js.snap
@@ -61,9 +61,38 @@ Immutable.Map {
           "data": "data",
         },
         "isLoading": false,
+        "_loadedOnServer": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`intl duck reducer should remove error & errorExpiration on successful language request 1`] = `
+Immutable.Map {
+  "activeLocale": "locale",
+  "languagePacks": Immutable.Map {
+    "locale": Immutable.Map {
+      "foo": Immutable.Map {
+        "isLoading": false,
+        "data": Immutable.Map {
+          "data": "data",
+        },
         "_loadedOnServer": false,
-        "errorExpiration": 11234,
-        "error": [Error: error],
+      },
+    },
+  },
+}
+`;
+
+exports[`intl duck reducer should remove error & errorExpiration on successful language request 2`] = `
+Immutable.Map {
+  "activeLocale": "locale",
+  "languagePacks": Immutable.Map {
+    "locale": Immutable.Map {
+      "foo": Immutable.Map {
+        "isLoading": true,
+        "data": Immutable.Map {},
       },
     },
   },
@@ -80,7 +109,7 @@ Immutable.Map {
           "data": "data",
         },
         "isLoading": false,
-        "_loadedOnServer": true,
+        "_loadedOnServer": false,
       },
     },
   },
@@ -97,7 +126,7 @@ Immutable.Map {
           "data": "data",
         },
         "isLoading": false,
-        "_loadedOnServer": false,
+        "_loadedOnServer": true,
       },
     },
   },

--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -295,6 +295,35 @@ describe('intl duck', () => {
       expect(reducer(state, failureAction)).toMatchSnapshot();
     });
 
+    it('should remove error & errorExpiration on successful language request', () => {
+      const oldState = fromJS({
+        activeLocale: 'locale',
+        languagePacks: {
+          locale: {
+            foo: {
+              isLoading: false,
+              data: {},
+              errorExpiration: 1223,
+              error: { name: 'timeouterror' },
+            },
+          },
+        },
+      });
+      const successAction = {
+        type: LANGUAGE_PACK_SUCCESS,
+        locale: 'locale',
+        componentKey: 'foo',
+        data: { data: 'data' },
+      };
+      expect(reducer(oldState, successAction)).toMatchSnapshot();
+      const requestAction = {
+        type: LANGUAGE_PACK_REQUEST,
+        locale: 'locale',
+        componentKey: 'foo',
+      };
+      expect(reducer(oldState, requestAction)).toMatchSnapshot();
+    });
+
     describe('update locale with mock data', () => {
       it('should update the state with mocked data', () => {
         const oldState = fromJS({ activeLocale: 'oldLocale' });

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -63,6 +63,8 @@ export default function reducer(state = buildInitialState(), action) {
         : state.updateIn(['languagePacks', locale, componentKey], iMap(), (nextState) => nextState.withMutations((map) => map
           .set('data', map.get('data', iMap()))
           .set('isLoading', true)
+          .delete('error')
+          .delete('errorExpiration')
         ));
     }
 
@@ -71,7 +73,9 @@ export default function reducer(state = buildInitialState(), action) {
       return state.updateIn(['languagePacks', locale, componentKey], iMap(), (nextState) => nextState.withMutations((map) => map
         .set('data', iMap(data))
         .set('isLoading', false)
-        .set('_loadedOnServer', !!global.BROWSER)
+        .set('_loadedOnServer', !global.BROWSER)
+        .delete('error')
+        .delete('errorExpiration')
       ));
     }
 


### PR DESCRIPTION
Blank page issue upon retrying language packs continuously

## Description
For Successful language REQUEST and DATA Action, remove the error and errorExpiration keys when the same is present already.

## Motivation and Context
This change will fix language pack being requested continuously. which results in Max update depth exceeded error. https://reactjs.org/docs/error-decoder.html?invariant=185

## How Has This Been Tested?
Tests are performed successfully in E0 environment, after it was reported by live customers.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
New version of one-app to be released, so that the framework will not throw blank page anymore.