### PR TITLE
BYO locale-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,11 @@ This action creator can take the following arguments:
 | Argument | Type | Description |
 |---|---|---|
 | `moduleName` | `String` | (required) Gets the language pack for the module specified. |
-| `givenLocale` | `String` | Gets the language pack for the given locale, as opposed to the locale in state. |
-| `force` | `String` | Force fetches the language pack if you don't want to use what is in state  |
-| `fallbackLocale` | `String` | If the language pack does not exist, fetches this lang pack instead.  |
+| `options.locale` | `String` | Gets the language pack for the given locale, as opposed to the locale in state. |
+| `options.url` | `String` | URL to fetch the language pack from if not using language packs generated via one-app-bundler |
+| `options.force` | `String` | Force fetches the language pack if you don't want to use what is in state  |
+| `options.fallbackLocale` | `String` | If the language pack does not exist, fetches this lang pack instead.  |
+| `options.fallbackUrl` | `String` | URL to use for fallback locale if not using language packs generated with one-app-bundler |
 
 ```js
 import { loadLanguagePack } from '@americanexpress/one-app-ducks';
@@ -375,7 +377,7 @@ import { loadLanguagePack } from '@americanexpress/one-app-ducks';
 
 export default holocronModule({
   name: 'my-module',
-  load: () => (dispatch) => dispatch(loadLanguagePack('my-module', null, null, 'en-US')),
+  load: () => (dispatch) => dispatch(loadLanguagePack('my-module', { locale: 'en-US' })),
 })(MyModule);
 ```
 

--- a/__tests__/errorReporting.spec.js
+++ b/__tests__/errorReporting.spec.js
@@ -397,7 +397,7 @@ describe('error reporting', () => {
     });
 
     it('should make a reporting network request after queuing a report and handle an empty response', async () => {
-      expect.assertions(4);
+      expect.assertions(3);
       const testError = {
         message: 'test error',
         stack: '1\n2\n3',
@@ -412,7 +412,7 @@ describe('error reporting', () => {
         applyMiddleware(thunk.withExtraArgument({ fetchClient: fetch }))
       );
 
-      fetch.mockResponseOnce();
+      fetch.mockResponse();
 
       const expectedReports = [
         {
@@ -424,7 +424,6 @@ describe('error reporting', () => {
       ];
 
       await store.dispatch(addErrorToReport(testError, otherData));
-      expect(fetch).not.toThrow();
       expect(
         JSON.parse(fetch.mock.calls[0][1].body)
       ).toEqual(expectedReports);

--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -76,7 +76,8 @@ TimeoutError.prototype = Object.create(Error.prototype, {
 });
 
 describe('intl duck', () => {
-  const consoleWarnSpy = jest.spyOn(console, 'warn');
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => 0);
+  jest.spyOn(console, 'info').mockImplementation(() => 0);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -349,6 +350,7 @@ describe('intl duck', () => {
     // TODO: test error scenarios when we are no longer mocking fetch
     describe('loadLanguagePack', () => {
       const locale = 'en-US';
+      const fallbackLocale = 'qya';
       const componentKey = 'foo-bar';
 
       const successfulRequestAction = {
@@ -363,7 +365,7 @@ describe('intl duck', () => {
         global.BROWSER = true;
       });
 
-      it('not loaded or loading', (done) => {
+      it('not loaded or loading', async () => {
         const store = mockStore({
           intl: fromJS({
             activeLocale: locale,
@@ -379,21 +381,14 @@ describe('intl duck', () => {
           },
         }));
 
-        store.dispatch(loadLanguagePack(componentKey))
-          .then(() => {
-            try {
-              expect(store.getActions()[0].type).toBe(LANGUAGE_PACK_REQUEST);
-              expect(store.getActions()[0].componentKey).toBe(componentKey);
-              expect(store.getActions()[0].locale).toBe(locale);
-              expect(store.getActions()[1]).toEqual({ data: fromJS({ test: 'not loaded or loading' }), ...successfulRequestAction });
-              done();
-            } catch (e) {
-              done(e);
-            }
-          });
+        await store.dispatch(loadLanguagePack(componentKey));
+        expect(store.getActions()[0].type).toBe(LANGUAGE_PACK_REQUEST);
+        expect(store.getActions()[0].componentKey).toBe(componentKey);
+        expect(store.getActions()[0].locale).toBe(locale);
+        expect(store.getActions()[1]).toEqual({ data: fromJS({ test: 'not loaded or loading' }), ...successfulRequestAction });
       });
 
-      it('loads', (done) => {
+      it('loads', async () => {
         const store = mockStore({
           intl: fromJS({
             activeLocale: locale,
@@ -404,19 +399,12 @@ describe('intl duck', () => {
           data: 'bar',
         }));
 
-        store.dispatch(loadLanguagePack(componentKey))
-          .then((resource) => {
-            try {
-              expect(store.getActions().length).toBe(2);
-              expect(resource).toEqual({ data: 'bar' });
-              done();
-            } catch (e) {
-              done.fail(e);
-            }
-          });
+        const resource = await store.dispatch(loadLanguagePack(componentKey));
+        expect(store.getActions().length).toBe(2);
+        expect(resource).toEqual({ data: 'bar' });
       });
 
-      it('is loaded', (done) => {
+      it('is loaded', async () => {
         const store = mockStore({
           intl: fromJS({
             activeLocale: locale,
@@ -431,16 +419,9 @@ describe('intl duck', () => {
           holocron: fromJS({}),
         });
 
-        store.dispatch(loadLanguagePack(componentKey))
-          .then((resource) => {
-            try {
-              expect(store.getActions().length).toBe(0);
-              expect(resource).toEqual(fromJS({ data: 'data' }));
-              done();
-            } catch (e) {
-              done.fail(e);
-            }
-          });
+        const resource = await store.dispatch(loadLanguagePack(componentKey));
+        expect(store.getActions().length).toBe(0);
+        expect(resource).toEqual(fromJS({ data: 'data' }));
       });
 
       it('is loaded on server', async () => {
@@ -489,10 +470,10 @@ describe('intl duck', () => {
           config: fromJS({}),
         });
 
-        fetch.mockResponseOnce(() => Promise.resolve({
-          status: 404,
-          body: JSON.stringify({ data: 'fallback' }),
-        }));
+        fetch.mockResponses([
+          [JSON.stringify({ data: 'fallback' })],
+          [JSON.stringify({}), { status: 404, statusText: 'Not found' }],
+        ]);
 
         const resource = await store.dispatch(loadLanguagePack(componentKey, { fallbackLocale: 'en-US' }));
         let actions = store.getActions();
@@ -548,7 +529,7 @@ describe('intl duck', () => {
           });
       });
 
-      it('is loading', (done) => {
+      it('is loading', async () => {
         const store = mockStore({
           intl: fromJS({
             activeLocale: 'en-US',
@@ -563,19 +544,12 @@ describe('intl duck', () => {
           holocron: fromJS({}),
         });
 
-        store.dispatch(loadLanguagePack(componentKey))
-          .then((resource) => {
-            try {
-              expect(store.getActions().length).toBe(0);
-              expect(resource).toEqual({ data: 'data' });
-              done();
-            } catch (e) {
-              done.fail(e);
-            }
-          });
+        const resource = await store.dispatch(loadLanguagePack(componentKey));
+        expect(store.getActions().length).toBe(0);
+        expect(resource).toEqual({ data: 'data' });
       });
 
-      it('last fetch failed', (done) => {
+      it('last fetch failed', async () => {
         fetch.mockResponseOnce(JSON.stringify({
           test: 'last fetch failed',
         }));
@@ -593,29 +567,90 @@ describe('intl duck', () => {
           config: fromJS({}),
         });
 
-        store.dispatch(loadLanguagePack(componentKey))
-          .then(() => {
-            try {
-              expect(store.getActions()[0].type).toBe(LANGUAGE_PACK_REQUEST);
-              expect(store.getActions()[0].componentKey).toBe(componentKey);
-              expect(store.getActions()[0].locale).toBe(locale);
-              expect(store.getActions()[1]).toEqual({ data: iMap({ test: 'last fetch failed' }), ...successfulRequestAction });
-              done();
-            } catch (e) {
-              done.fail(e);
-            }
-          });
+        await store.dispatch(loadLanguagePack(componentKey));
+        expect(store.getActions()[0].type).toBe(LANGUAGE_PACK_REQUEST);
+        expect(store.getActions()[0].componentKey).toBe(componentKey);
+        expect(store.getActions()[0].locale).toBe(locale);
+        expect(store.getActions()[1]).toEqual({ data: iMap({ test: 'last fetch failed' }), ...successfulRequestAction });
       });
 
-      it('should handle no activeLocale', (done) => {
+      it('should use a custom URL when provided', async () => {
+        const url = `https://example.com/language/${componentKey}/${locale}`;
+        const store = mockStore({
+          intl: fromJS({
+            activeLocale: locale,
+          }),
+          config: fromJS({}),
+        });
+        fetch.mockResponseOnce(async (req) => {
+          if (req.url === url) {
+            return { body: JSON.stringify({ data: 'custom language' }) };
+          }
+          throw new Error(`Unexpected URL: ${req.url}`);
+        });
+
+        const resource = await store.dispatch(loadLanguagePack(componentKey, { url }));
+        expect(store.getActions().length).toBe(2);
+        expect(resource).toEqual({ data: 'custom language' });
+      });
+
+      it('should use the fallback custom URL when provided', async () => {
+        const url = `https://example.com/language/${componentKey}/${locale}`;
+        const fallbackUrl = `https://example.com/language/${componentKey}/${fallbackLocale}`;
+        const store = mockStore({
+          intl: fromJS({
+            activeLocale: locale,
+          }),
+          config: fromJS({}),
+        });
+        fetch.mockResponse(async (req) => {
+          if (req.url === url) {
+            return { body: '', status: 404, statusText: 'Not Found' };
+          }
+          if (req.url === fallbackUrl) {
+            return { body: JSON.stringify({ data: 'fallback custom language' }) };
+          }
+          throw new Error(`Unexpected URL: ${req.url}`);
+        });
+
+        const resource = await store.dispatch(loadLanguagePack(componentKey, {
+          url,
+          fallbackLocale,
+          fallbackUrl,
+        }));
+        expect(store.getActions().length).toBe(2);
+        expect(resource).toEqual({ data: 'fallback custom language' });
+      });
+
+      it('should throw an error if there is a fallback URL and no fallback locale', async () => {
+        expect.assertions(1);
+        const url = `https://example.com/language/${componentKey}/${locale}`;
+        const fallbackUrl = `https://example.com/language/${componentKey}/${fallbackLocale}`;
+        const store = mockStore({
+          intl: fromJS({
+            activeLocale: locale,
+          }),
+          config: fromJS({}),
+        });
+
+        try {
+          await store.dispatch(loadLanguagePack(componentKey, { url, fallbackUrl }));
+        } catch (error) {
+          expect(error).toEqual(new Error('Fallback locale is required when fallback URL is provided for language pack'));
+        }
+      });
+
+      it('should handle no activeLocale', async () => {
+        expect.assertions(1);
         const store = mockStore({
           intl: fromJS({}),
           holocron: fromJS({}),
         });
-        store.dispatch(loadLanguagePack('foo')).catch((error) => {
+        try {
+          await store.dispatch(loadLanguagePack('foo'));
+        } catch (error) {
           expect(error).toEqual(new Error('Failed to load language pack. No locale was set or given'));
-          done();
-        });
+        }
       });
 
       it('should throw when there is a non-404 error response', async () => {
@@ -720,14 +755,10 @@ describe('intl duck', () => {
         beforeEach(() => {
           global.BROWSER = false;
           serverLangPackCache.mock.reset();
-          jest.spyOn(console, 'info');
         });
 
-        afterEach(() => {
-          console.info.mockRestore();
-        });
-
-        it('caches good responses and uses the cache', () => {
+        it('caches good responses and uses the cache', async () => {
+          expect.assertions(6);
           const store = mockStore({
             intl: fromJS({
               activeLocale: locale,
@@ -745,24 +776,18 @@ describe('intl duck', () => {
           const staticLocale = `https://example.com/cdn/foo-bar/1.0.0/${locale.toLowerCase()}/${componentKey}.json`;
           fetch.mockResponseOnce(JSON.stringify({ test: 'caches good responses and uses the cache' }));
 
-          expect.assertions(6);
+          const resource = await store.dispatch(loadLanguagePack(componentKey));
+          expect(resource).toEqual({ test: 'caches good responses and uses the cache' });
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(console.info).toHaveBeenCalledWith(`setting serverLangPackCache: url ${staticLocale}, data`, { test: 'caches good responses and uses the cache' });
 
-          return store.dispatch(loadLanguagePack(componentKey))
-            .then((resource) => {
-              expect(resource).toEqual({ test: 'caches good responses and uses the cache' });
-              expect(fetch).toHaveBeenCalledTimes(1);
-              expect(console.info).toHaveBeenCalledWith(`setting serverLangPackCache: url ${staticLocale}, data`, { test: 'caches good responses and uses the cache' });
-
-              return store.dispatch(loadLanguagePack(componentKey));
-            })
-            .then((resource) => {
-              expect(resource).toEqual({ test: 'caches good responses and uses the cache' });
-              expect(fetch).toHaveBeenCalledTimes(1);
-              expect(console.info).toHaveBeenCalledWith(`using serverLangPackCache for ${staticLocale}`);
-            });
+          const cachedResource = await store.dispatch(loadLanguagePack(componentKey));
+          expect(cachedResource).toEqual({ test: 'caches good responses and uses the cache' });
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(console.info).toHaveBeenCalledWith(`using serverLangPackCache for ${staticLocale}`);
         });
 
-        it('does not cache bad responses', () => {
+        it('does not cache bad responses', async () => {
           const store = mockStore({
             intl: fromJS({
               activeLocale: locale,
@@ -783,19 +808,15 @@ describe('intl duck', () => {
 
           expect.assertions(6);
 
-          return store.dispatch(loadLanguagePack(componentKey))
-            .then((resource) => {
-              expect(resource).toEqual({});
-              expect(fetch).toHaveBeenCalledTimes(1);
-              expect(console.info).not.toHaveBeenCalled();
+          const resource = await store.dispatch(loadLanguagePack(componentKey));
+          expect(resource).toEqual({});
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(console.info).not.toHaveBeenCalled();
 
-              return store.dispatch(loadLanguagePack(componentKey));
-            })
-            .then((resource) => {
-              expect(resource).toEqual({ test: 'does not cache bad responses' });
-              expect(fetch).toHaveBeenCalledTimes(2);
-              expect(console.info).toHaveBeenCalledWith(`setting serverLangPackCache: url ${staticLocale}, data`, { test: 'does not cache bad responses' });
-            });
+          const cachedResource = await store.dispatch(loadLanguagePack(componentKey));
+          expect(cachedResource).toEqual({ test: 'does not cache bad responses' });
+          expect(fetch).toHaveBeenCalledTimes(2);
+          expect(console.info).toHaveBeenCalledWith(`setting serverLangPackCache: url ${staticLocale}, data`, { test: 'does not cache bad responses' });
         });
       });
     });
@@ -989,7 +1010,7 @@ describe('intl duck', () => {
       });
     });
 
-    it('updateLocale', (done) => {
+    it('updateLocale', async () => {
       const locale = 'en-NZ';
       const store = mockStore({
         intl: fromJS({}),
@@ -1001,16 +1022,8 @@ describe('intl duck', () => {
         locale,
       };
 
-      store.dispatch(updateLocale(locale))
-        .then(() => {
-          try {
-            expect(store.getActions()[0]).toEqual(updateLocaleAction);
-            done();
-          } catch (e) {
-            done.fail(e);
-          }
-        })
-        .catch((e) => done.fail(e));
+      await store.dispatch(updateLocale(locale));
+      expect(store.getActions()[0]).toEqual(updateLocaleAction);
     });
 
     describe('updateLocale actions test', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "glob": "^7.1.3",
         "husky": "^3.0.9",
         "jest": "^24.9.0",
-        "jest-fetch-mock": "^2.1.2",
+        "jest-fetch-mock": "^3.0.3",
         "lockfile-lint": "^4.3.7",
         "lolex": "^1.4.0",
         "mkdirp": "^0.5.1",
@@ -5349,13 +5349,12 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.6.tgz",
-      "integrity": "sha512-9JZz+vXCmfKUZ68zAptS7k4Nu8e2qcibe7WVZYps7sAgk5R8GYTc+T1WR0v1rlP9HxgARmOX1UTIJZFytajpNA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
       "dependencies": {
-        "node-fetch": "^2.6.7",
-        "whatwg-fetch": "^2.0.4"
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -10462,13 +10461,13 @@
       }
     },
     "node_modules/jest-fetch-mock": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
-      "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
       "dev": true,
       "dependencies": {
-        "cross-fetch": "^2.2.2",
-        "promise-polyfill": "^7.1.1"
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "node_modules/jest-haste-map": {
@@ -15530,9 +15529,9 @@
       }
     },
     "node_modules/promise-polyfill": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
-      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "node_modules/prompts": {
@@ -18486,12 +18485,6 @@
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
@@ -23005,13 +22998,12 @@
       }
     },
     "cross-fetch": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.6.tgz",
-      "integrity": "sha512-9JZz+vXCmfKUZ68zAptS7k4Nu8e2qcibe7WVZYps7sAgk5R8GYTc+T1WR0v1rlP9HxgARmOX1UTIJZFytajpNA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
       "requires": {
-        "node-fetch": "^2.6.7",
-        "whatwg-fetch": "^2.0.4"
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -26977,13 +26969,13 @@
       }
     },
     "jest-fetch-mock": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
-      "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
       "dev": true,
       "requires": {
-        "cross-fetch": "^2.2.2",
-        "promise-polyfill": "^7.1.1"
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "jest-haste-map": {
@@ -30739,9 +30731,9 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
-      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "prompts": {
@@ -33080,12 +33072,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "glob": "^7.1.3",
     "husky": "^3.0.9",
     "jest": "^24.9.0",
-    "jest-fetch-mock": "^2.1.2",
+    "jest-fetch-mock": "^3.0.3",
     "lockfile-lint": "^4.3.7",
     "lolex": "^1.4.0",
     "mkdirp": "^0.5.1",

--- a/setupJest.js
+++ b/setupJest.js
@@ -15,4 +15,4 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 require('@babel/polyfill');
 // eslint-disable-next-line import/no-extraneous-dependencies
-global.fetch = require('jest-fetch-mock');
+require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
## Description

Added option to use your own URL for your locale pack instead of using a locale pack generated by one-app-bundler.
Also, fixed some inaccurate docs

builds on #55 

## Motivation and Context

This feature will allow users to get their locale data from their own API or CMS with the same advantages as they would get using the generated locale packs.

## How Has This Been Tested?

- Installed build in one-app
- made json-server with locale data
- updated cultured-frankie to get locale data from json-server instead of generated locale packs
- ran app locally with cultured-frankie as root
- verified json-server was being used for locale data
- switched between locales
- validated caching was happening in client and on server

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [x] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?

More options for locale data fetching