### PR TITLE
refactor: provide more info about invalid locale

### DIFF
--- a/__tests__/intl/__snapshots__/index.spec.js.snap
+++ b/__tests__/intl/__snapshots__/index.spec.js.snap
@@ -28,7 +28,7 @@ exports[`intl duck actions updateLocale actions test should allow any valid BCP 
 }
 `;
 
-exports[`intl duck actions updateLocale actions test should reject a valid BCP 47 locale if enableAllIntlLocales is true and Intl.js does not have a bundle for it 1`] = `[Error: No locale bundle available for tlh]`;
+exports[`intl duck actions updateLocale actions test should reject a valid BCP 47 locale if enableAllIntlLocales is true and Intl.js does not have a bundle for it 1`] = `[Error: No locale bundle available for "tlh" (type string)]`;
 
 exports[`intl duck actions updateLocale actions test should reject if no locale is given 1`] = `"No locale was given"`;
 

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -402,7 +402,7 @@ export function getLocalePack(locale) {
     return localePack();
   }
 
-  return Promise.reject(new Error(`No locale bundle available for ${locale}`));
+  return Promise.reject(new Error(`No locale bundle available for "${locale}" (type ${typeof locale})`));
 }
 
 export function updateLocale(locale) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provide more information about an invalid `locale`

## Description
<!--- Describe your changes in detail -->
`locale` could be a string `"undefined"` which is misleading. By logging the type we can know if it's actually `undefined` or a string `"undefined"`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There's an existing error `Error: No locale bundle available for undefined` which should not be possible to get since `updateLocale` checks the value of `locale`, the only way to get such value is if the `undefined` is a string

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit testing

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
<!--- Please describe how your changes impacts developers using one-app-ducks. -->
