### PR TITLE
fix(intl): return actual promise, resolve as loaded does

### DIFF
--- a/__tests__/intl/__snapshots__/index.spec.js.snap
+++ b/__tests__/intl/__snapshots__/index.spec.js.snap
@@ -93,6 +93,7 @@ Immutable.Map {
       "foo": Immutable.Map {
         "isLoading": true,
         "data": Immutable.Map {},
+        "promise": Promise {},
       },
     },
   },

--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -139,10 +139,12 @@ describe('intl duck', () => {
 
     it('language pack request action', () => {
       const oldState = fromJS({ activeLocale: 'locale' });
+      const promise = Promise.resolve();
       const action = {
         type: LANGUAGE_PACK_REQUEST,
         locale: 'locale',
         componentKey: 'foo',
+        promise,
       };
       const newState = {
         activeLocale: 'locale',
@@ -151,6 +153,7 @@ describe('intl duck', () => {
             foo: {
               isLoading: true,
               data: {},
+              promise,
             },
           },
         },
@@ -173,6 +176,7 @@ describe('intl duck', () => {
         type: LANGUAGE_PACK_REQUEST,
         locale: 'locale',
         componentKey: 'foo',
+        promise: Promise.resolve(),
       };
       const newState = {
         activeLocale: 'locale',
@@ -322,6 +326,7 @@ describe('intl duck', () => {
         type: LANGUAGE_PACK_REQUEST,
         locale: 'locale',
         componentKey: 'foo',
+        promise: Promise.resolve(),
       };
       expect(reducer(oldState, requestAction)).toMatchSnapshot();
     });
@@ -537,7 +542,8 @@ describe('intl duck', () => {
             languagePacks: {
               'en-US': {
                 [componentKey]: {
-                  isLoading: Promise.resolve({ data: 'data' }),
+                  isLoading: true,
+                  promise: Promise.resolve({ data: 'data' }),
                 },
               },
             },


### PR DESCRIPTION
Store and return the real request promise and resolve it as it would if fully loaded.

## Description
Added a new state key to store the loading promise and fixed the internal selector to return it instead of the `isLoading` value. Additionally, to make sure the promise resolves to the same value it would if it were loaded the promise will `finally` resolve using `getResourceFromState` as it would when loaded.

## Motivation and Context
Looking to use `loadLanguagePack` directly and it was not working if it was mid-loading and called again. It would return a boolean instead of a promise.

## How Has This Been Tested?
Unit tested that the response is as expected when the promise is resolved if it starts already loading.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
Improvement to this functionality as a bug is now resolved.
