### PR TITLE
fix(memoryLeak): track loaded locales with a set

### DIFF
--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -36,6 +36,7 @@ import reducer, {
   LANGUAGE_PACK_SUCCESS,
   LANGUAGE_PACK_FAILURE,
   LANGUAGE_PACK_DEFERRED_FORCE_LOAD,
+  loadedLocales,
 } from '../../src/intl';
 
 jest.mock('holocron', () => ({
@@ -1070,6 +1071,16 @@ describe('intl duck', () => {
       await expect(getLocalePack('xx-XX')).resolves.toBe('xx');
       await expect(getLocalePack('xx-Xxxx-XX')).resolves.toBe('xx');
       await expect(getLocalePack('yy-Yyyy-YY')).resolves.toBe('yy-Yyyy');
+    });
+    it('should only load each langpack once', async () => {
+      loadedLocales.clear();
+      getLocalePack('zz-XA');
+      getLocalePack('xx-XX');
+      getLocalePack('xx-Xxxx-XX');
+      getLocalePack('yy-Yyyy-YY');
+      // call the same locale to verify its not added twice
+      getLocalePack('yy-Yyyy-YY');
+      expect(loadedLocales.size).toBe(4);
     });
   });
 });

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -389,6 +389,8 @@ export function queryLanguagePack(componentKey, { fallbackLocale } = {}) {
   };
 }
 
+export const loadedLocales = new Set();
+
 export function getLocalePack(locale) {
   const localeArray = locale.split('-');
   let localePack;
@@ -399,7 +401,11 @@ export function getLocalePack(locale) {
   }
 
   if (localePack) {
-    return localePack();
+    if (!loadedLocales.has(locale)) {
+      loadedLocales.add(locale);
+      return localePack();
+    }
+    return Promise.resolve();
   }
 
   return Promise.reject(new Error(`No locale bundle available for "${locale}" (type ${typeof locale})`));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When a use ran `updateLocale` on the server, the `lean-intl` package would keep track of each locale loaded by storing the locale (`en-US`, `es-MX`, etc...) in an array.

Regardless of whether or not the locale was already loaded, it would always add to the array, which grows the memory needlessly.

This is a work-around to the `lean-intl` issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

memory leaks are bad

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran one-app locally, and verified the `lean-intl` package wasn't adding duplicate locales.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
<!--- Please describe how your changes impacts developers using one-app-ducks. -->
