### PR TITLE
docs(readme): correct type for loadLanguagePack option

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ This action creator can take the following arguments:
 | `moduleName` | `String` | (required) Gets the language pack for the module specified. |
 | `options.locale` | `String` | Gets the language pack for the given locale, as opposed to the locale in state. |
 | `options.url` | `String` | URL to fetch the language pack from if not using language packs generated via one-app-bundler |
-| `options.force` | `String` | Force fetches the language pack if you don't want to use what is in state  |
+| `options.force` | `Boolean` | Force fetches the language pack if you don't want to use what is in state  |
 | `options.fallbackLocale` | `String` | If the language pack does not exist, fetches this lang pack instead.  |
 | `options.fallbackUrl` | `String` | URL to use for fallback locale if not using language packs generated with one-app-bundler |
 


### PR DESCRIPTION
## Description
Fixes the type for the `force` option for `loadLanguagePack`.

## Motivation and Context
This is a boolean, not a string:
https://github.com/americanexpress/one-app-ducks/blob/8e50d8ff9bed1fe58693814033ca4ecbd330696a/src/intl/index.js#L295

## How Has This Been Tested?
Doc update.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
Corrected documentation.