### PR TITLE
Feat/conditional native intl

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,13 +409,15 @@ const loadDataAsProps = ({ store: { dispatch } }) => ({
 This action creator is used to set the active locale for One App.
 The promise will resolve once the
 locale bundle (containing locale data for `Intl.js`,
-[`React Intl`](https://www.npmjs.com/package/react-intl)) and
+[`React Intl`](https://www.npmjs.com/package/react-intl) and
 [`Moment.js`](http://momentjs.com/)) is loaded and the active locale is set. It will reject if
 [Lean-Intl](https://github.com/sebastian-software/lean-intl) does not have a bundle for the locale.
 
 The locale bundles don't need to be an exact match. For instance setting the
 locale to `'en-XA'` will load `i18n/en.js` and `'zh-Hans-XB'` will load
 `i18n/zh-Hans.js`.
+
+If the Environment Variable `ONE_CONFIG_USE_NATIVE_INTL` is set to `true`, then `updateLocale` will not try to add the Lean-Intl bundle, but will still update the active locale.
 
 This action creator can take the following argument:
 

--- a/__tests__/intl/__snapshots__/index.spec.js.snap
+++ b/__tests__/intl/__snapshots__/index.spec.js.snap
@@ -21,6 +21,13 @@ exports[`intl duck actions loadLanguagePack should throw when the error does not
 
 exports[`intl duck actions loadLanguagePack should throw when there is a non-404 error response 1`] = `[Error: Internal Server Error (https://example.com/cdn/foo-bar/1.0.0/bd-lc/foo-bar.json)]`;
 
+exports[`intl duck actions should not call getLocalePack when useNativeIntl env var is true 1`] = `
+{
+  "locale": "en-GB",
+  "type": "@americanexpress/one-app-ducks/intl/UPDATE_LOCALE",
+}
+`;
+
 exports[`intl duck actions updateLocale actions test should allow any valid BCP 47 locale if enableAllIntlLocales is true 1`] = `
 {
   "locale": "be-BY",

--- a/__tests__/intl/index.spec.js
+++ b/__tests__/intl/index.spec.js
@@ -1072,6 +1072,14 @@ describe('intl duck', () => {
           });
       });
     });
+
+    it('should not call getLocalePack when useNativeIntl env var is true', async () => {
+      window.useNativeIntl = true;
+      const store = mockStore({ config: fromJS({ enableAllIntlLocales: 'true' }) });
+      await store.dispatch(updateLocale('en-GB'));
+      expect(store.getActions()[0]).toMatchSnapshot();
+      expect(loadedLocales.has('en-GB')).toEqual(false);
+    });
   });
 
   describe('getLocalePack', () => {

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -432,13 +432,21 @@ export function updateLocale(locale) {
       return Promise.reject(new Error('No locale was given'));
     }
 
+    const action = {
+      type: UPDATE_LOCALE,
+      locale,
+    };
+
+    if (window?.useNativeIntl || process.env.ONE_CONFIG_USE_NATIVE_INTL === 'true') {
+      return Promise.resolve().then(() => {
+        dispatch(action);
+      });
+    }
+
     // supporting files for locale dependent libraries
     return getLocalePack(locale)
       .then(() => {
-        dispatch({
-          type: UPDATE_LOCALE,
-          locale,
-        });
+        dispatch(action);
       });
   };
 }


### PR DESCRIPTION
## Description
Changed the `updateLocale` function so that it will work consistently with the One App environment variable `ONE_CONFIG_USE_NATIVE_INTL`.

## Motivation and Context
This makes the environment variable consistent in not including Lean-Intl. When the environment variable is enabled, `updateLocale` will still dispatch the action to update the active locale but not add the Lean-Intl bundles.

Relevant One App PR: https://github.com/americanexpress/one-app/pull/1258

## How Has This Been Tested?
Ran the changes in a test module along with the branch in the One App PR. Validated that using `updateLocale` with the environment variable set to true would not add the bundle, but would update the active locale and switches locales for `react-intl`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
When using the `ONE_CONFIG_USE_NATIVE_INTL` environment variable, Lean-Intl bundles will not get added when using `updateLocale`.
