### PR TITLE
perf(intl): lower log level for language pack cache

### DIFF
--- a/__tests__/.eslintrc.json
+++ b/__tests__/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "amex/test"
+  "extends": "amex/test",
+  "rules": {
+    "no-console": "off",
+    "global-require": "off"
+  }
 }

--- a/__tests__/intl/server-cache.spec.js
+++ b/__tests__/intl/server-cache.spec.js
@@ -28,7 +28,7 @@ describe('server-cache', () => {
     // overwrite setInterval to provide unref for server-cache
     const lolexSetInterval = global.setInterval;
     intervalUnref = jest.fn();
-    global.setInterval = function (...args) {
+    global.setInterval = function mockSetInterval(...args) {
       const id = lolexSetInterval.apply(this, args);
       if (dontUseNodeTimers) return id;
       return {
@@ -38,7 +38,6 @@ describe('server-cache', () => {
     };
 
     jest.resetModules();
-    // eslint-disable-next-line global-require -- dynamic require
     const serverCache = require('../../src/intl/server-cache');
     set = serverCache.set;
     get = serverCache.get;
@@ -142,7 +141,7 @@ describe('server-cache', () => {
     });
 
     it('does not prevent testing in jsdom environments', () => {
-      setupCache(true);
+      expect(() => setupCache(true)).not.toThrow();
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7123,9 +7123,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001410",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001410.tgz",
-      "integrity": "sha512-QoblBnuE+rG0lc3Ur9ltP5q47lbguipa/ncNMyyGuqPk44FxbScWAeEO+k5fSQ8WekdAK4mWqNs1rADDAiN5xQ==",
+      "version": "1.0.30001593",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz",
+      "integrity": "sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==",
       "dev": true,
       "funding": [
         {
@@ -7135,6 +7135,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -31528,9 +31532,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001410",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001410.tgz",
-      "integrity": "sha512-QoblBnuE+rG0lc3Ur9ltP5q47lbguipa/ncNMyyGuqPk44FxbScWAeEO+k5fSQ8WekdAK4mWqNs1rADDAiN5xQ==",
+      "version": "1.0.30001593",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz",
+      "integrity": "sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==",
       "dev": true
     },
     "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebuild": "npm run clean",
     "build:ejs": "node scripts/render-ejs.js",
     "build:node": "node scripts/build-node-imports.js",
-    "build:src": "babel src --out-dir lib --verbose --copy-files",
+    "build:src": "babel src --out-dir lib --verbose --copy-files && rimraf lib/**/__mocks__",
     "build": "npm run build:src && npm run build:ejs && npm run build:node",
     "pretest": "npm run build",
     "test:lint": "eslint --ignore-path .gitignore --ext js,jsx,snap,md .",

--- a/src/errorReporting.js
+++ b/src/errorReporting.js
@@ -53,7 +53,8 @@ export default function errorReportingReducer(state = defaultState, action) {
   switch (action.type) {
     case ADD_ERROR_REPORT_TO_QUEUE:
       if (!(action.error || action.otherData)) {
-        console.warn('no error xor otherData given to report, probably due to localhost quirks');
+        // eslint-disable-next-line no-console -- logging
+        console.warn('no error or otherData given to report, probably due to localhost quirks');
         return state;
       }
       return state.set(
@@ -108,6 +109,7 @@ export function serverSideError(queue) {
       stack,
       metaData: { ...otherData },
     });
+    // eslint-disable-next-line no-console -- logging
     console.error(err);
   });
   return Promise.resolve({ thankYou: true });

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -177,7 +177,7 @@ const fetchLanguagePack = ({
     const cached = serverLangPackCache.get(url, defaultUrl);
     if (cached) {
       // eslint-disable-next-line no-console -- logging
-      console.info(`using serverLangPackCache for ${url}`);
+      console.debug('using serverLangPackCache for %s', url);
       return Promise.resolve(cached);
     }
   }
@@ -192,7 +192,7 @@ const fetchLanguagePack = ({
     .then((data) => {
       if (!global.BROWSER) {
         // eslint-disable-next-line no-console -- logging
-        console.info(`setting serverLangPackCache: url ${url}, data`, data);
+        console.debug('setting serverLangPackCache: url %s, data %o', url, data);
         serverLangPackCache.set(url, data, defaultUrl);
       }
       return data;
@@ -205,7 +205,8 @@ const fetchLanguagePack = ({
       const { status, statusText, url: responseUrl } = errorOrResponse;
 
       if (status === 404 && fallbackLocale && locale !== fallbackLocale && !retry) {
-        console.warn(`Missing ${locale} language pack for ${componentKey}, falling back to ${fallbackLocale}.`);
+        // eslint-disable-next-line no-console -- logging
+        console.warn('Missing %s language pack for %s, falling back to %s.', locale, componentKey, fallbackLocale);
         return fetchLanguagePack({
           getState,
           dispatch,


### PR DESCRIPTION
## Description

Lower language pack cache log level from info to debug

## Motivation and Context

The using cache log can be printed several times per request and when working, the setting cache logs can be very large & will repeat every 10 min. The existing setting cache log does not work since pino migration.

Removing these from the default log level used in production will improve performance as well as DX (for reviewing logs).

Closes #29 

## How Has This Been Tested?

- Updated unit tests
- Packed and installed to one-app and manually validated

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [x] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
<!--- Please describe how your changes impacts developers using one-app-ducks. -->

Fewer low value logs by default