### PR TITLE
fix(updateLocale): fix window reference in node environments

### DIFF
--- a/__tests__/intl/__snapshots__/index.node.spec.js.snap
+++ b/__tests__/intl/__snapshots__/index.node.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`intl duck actions should not call getLocalePack when process.env.ONE_CONFIG_USE_NATIVE_INTL env var is true, if window is undefined 1`] = `
+{
+  "locale": "en-GB",
+  "type": "@americanexpress/one-app-ducks/intl/UPDATE_LOCALE",
+}
+`;

--- a/__tests__/intl/index.node.spec.js
+++ b/__tests__/intl/index.node.spec.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+
+/*
+ * Copyright 2024 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint no-unused-expressions:0, no-underscore-dangle:0 -- disable for test */
+import { fromJS } from 'immutable';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import Intl from 'lean-intl';
+
+// Module under test
+import {
+  updateLocale,
+  loadedLocales,
+} from '../../src/intl';
+
+global.Intl = Intl;
+
+jest.mock('../../src/intl/localePacks.client', () => require('../../lib/intl/localePacks.client'), { virtual: true });
+jest.mock('../../src/intl/localePacks.node', () => {
+  const realLocalePacks = require('../../lib/intl/localePacks.node');
+  const mockLocalePacks = {
+    xx: jest.fn(() => Promise.resolve('xx')),
+    'yy-Yyyy': jest.fn(() => Promise.resolve('yy-Yyyy')),
+    'zz-XA': jest.fn(() => Promise.resolve('zz-XA')),
+  };
+
+  return { ...realLocalePacks, ...mockLocalePacks };
+}, { virtual: true });
+
+describe('intl duck', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetch.resetMocks();
+  });
+
+  describe('actions', () => {
+    const middlewares = [thunk.withExtraArgument({ fetchClient: fetch })];
+    const mockStore = (initialState) => configureStore(middlewares)(fromJS(initialState));
+
+    it('should not call getLocalePack when process.env.ONE_CONFIG_USE_NATIVE_INTL env var is true, if window is undefined', async () => {
+      process.env.ONE_CONFIG_USE_NATIVE_INTL = true;
+      const store = mockStore({ config: fromJS({ enableAllIntlLocales: 'true' }) });
+      await store.dispatch(updateLocale('en-GB'));
+      expect(store.getActions()[0]).toMatchSnapshot();
+      expect(loadedLocales.has('en-GB')).toEqual(false);
+    });
+  });
+});

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -438,7 +438,7 @@ export function updateLocale(locale) {
       locale,
     };
 
-    if (window?.useNativeIntl || process.env.ONE_CONFIG_USE_NATIVE_INTL === 'true') {
+    if (globalThis.window?.useNativeIntl || process.env.ONE_CONFIG_USE_NATIVE_INTL === 'true') {
       return Promise.resolve().then(() => {
         dispatch(action);
       });


### PR DESCRIPTION
## Description
In `node` environments, such as inside of SSR servers, referencing `window` with a conditional chain is not sufficient, since the exception `window is not defined` will be thrown.

Instead you need to de-reference `globalThis` with `window`, allowing for the _value_ `undefined` to be returned, which then feeds into the conditional chain properly

## Motivation and Context
This is a bug, the package will crash in node environments

## How Has This Been Tested?
Loading into one-app integration tests.
Unit test that would fail without this fix.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-ducks users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-ducks?
<!--- Please describe how your changes impacts developers using one-app-ducks. -->
